### PR TITLE
Fix filtering for specific teacher names

### DIFF
--- a/app/lib/applets/substitutions/parser.dart
+++ b/app/lib/applets/substitutions/parser.dart
@@ -10,6 +10,7 @@ import 'package:intl/intl.dart';
 import '../../core/applet_parser.dart';
 import '../../models/client_status_exceptions.dart';
 import '../../models/substitution.dart';
+import '../../utils/logger.dart';
 
 class SubstitutionsParser extends AppletParser<SubstitutionPlan> {
   final DateFormat entryFormat = DateFormat('dd_MM_yyyy');
@@ -258,6 +259,7 @@ class SubstitutionsParser extends AppletParser<SubstitutionPlan> {
   }
 
   bool filterElement(String? value, List<String> filter, bool? strict) {
+    logger.d("Filtering value: $value with filter: $filter and strict: $strict");
     if (value == null) {
       return false;
     }

--- a/app/lib/applets/substitutions/parser.dart
+++ b/app/lib/applets/substitutions/parser.dart
@@ -256,4 +256,15 @@ class SubstitutionsParser extends AppletParser<SubstitutionPlan> {
 
     return infos;
   }
+
+  bool filterElement(String? value, List<String> filter, bool? strict) {
+    if (value == null) {
+      return false;
+    }
+    if (strict == true) {
+      return filter.any((element) => value == element);
+    } else {
+      return filter.any((element) => value.contains(element));
+    }
+  }
 }

--- a/app/lib/applets/substitutions/parser.dart
+++ b/app/lib/applets/substitutions/parser.dart
@@ -263,7 +263,7 @@ class SubstitutionsParser extends AppletParser<SubstitutionPlan> {
       return false;
     }
     if (strict == true) {
-      return filter.any((element) => value == element);
+      return filter.any((element) => value == element && value.length == element.length);
     } else {
       return filter.any((element) => value.contains(element));
     }

--- a/app/lib/applets/substitutions/parser.dart
+++ b/app/lib/applets/substitutions/parser.dart
@@ -259,7 +259,6 @@ class SubstitutionsParser extends AppletParser<SubstitutionPlan> {
   }
 
   bool filterElement(String? value, List<String> filter, bool? strict) {
-    logger.d("Filtering value: $value with filter: $filter and strict: $strict");
     if (value == null) {
       return false;
     }

--- a/app/lib/models/substitution.dart
+++ b/app/lib/models/substitution.dart
@@ -100,15 +100,11 @@ class Substitution {
     if (value == null) {
       return false;
     }
-    if (!(strict ?? true)) {
+    if (strict == true) {
+      return filter.any((element) => value == element);
+    } else {
       return filter.any((element) => value.contains(element));
     }
-    for (var singleFilter in filter) {
-      if (!value.contains(singleFilter)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   Map<String, dynamic> toJson() => {

--- a/app/lib/models/substitution.dart
+++ b/app/lib/models/substitution.dart
@@ -97,7 +97,6 @@ class Substitution {
 
   ///returns true if the value contains all of the filter elements
   bool filterElement(String? value, List<String> filter, bool? strict) {
-    logger.d("Filtering value: $value with filter: $filter and strict: $strict");
     if (value == null) {
       return false;
     }

--- a/app/lib/models/substitution.dart
+++ b/app/lib/models/substitution.dart
@@ -97,6 +97,7 @@ class Substitution {
 
   ///returns true if the value contains all of the filter elements
   bool filterElement(String? value, List<String> filter, bool? strict) {
+    logger.d("Filtering value: $value with filter: $filter and strict: $strict");
     if (value == null) {
       return false;
     }


### PR DESCRIPTION
Update filtering logic to support exact matches for strict filtering.

* Modify `filterElement` method in `app/lib/applets/substitutions/parser.dart` to check for exact matches when `strict` is true.
* Update `filterElement` method in `app/lib/models/substitution.dart` to support exact matches for strict filtering. 
