### PR TITLE
Add import/export timetable settings

### DIFF
--- a/app/lib/applets/definitions.dart
+++ b/app/lib/applets/definitions.dart
@@ -7,6 +7,9 @@ import 'package:sph_plan/applets/study_groups/definitions.dart';
 import 'package:sph_plan/applets/substitutions/definition.dart';
 import 'package:sph_plan/applets/timetable/definition.dart';
 import 'package:sph_plan/models/account_types.dart';
+import 'dart:convert';
+import 'dart:io';
+import 'package:file_picker/file_picker.dart';
 
 import '../background_service.dart';
 import '../core/sph/sph.dart';
@@ -84,6 +87,14 @@ class AppletDefinition {
       await file.writeAsString(jsonString);
       showSnackbar(context, 'Timetable settings exported successfully.');
     }
+  }
+
+  void showSnackbar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+      ),
+    );
   }
 }
 

--- a/app/lib/applets/definitions.dart
+++ b/app/lib/applets/definitions.dart
@@ -50,6 +50,41 @@ class AppletDefinition {
     this.bodyBuilder,
     this.allowOffline = false,
   });
+
+  Future<void> importTimetableSettings(
+      Future<void> Function(String, dynamic) updateSettings) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+
+    if (result != null && result.files.isNotEmpty) {
+      final file = File(result.files.single.path!);
+      final jsonString = await file.readAsString();
+      final Map<String, dynamic> importedSettings = jsonDecode(jsonString);
+
+      for (var key in importedSettings.keys) {
+        await updateSettings(key, importedSettings[key]);
+      }
+
+      showSnackbar(context, 'Timetable settings imported successfully.');
+    }
+  }
+
+  Future<void> exportTimetableSettings(Map<String, dynamic> settings) async {
+    final jsonString = jsonEncode(settings);
+    final fileName = 'timetable_settings.json';
+    final result = await FilePicker.platform.saveFile(
+      dialogTitle: 'Save Timetable Settings',
+      fileName: fileName,
+    );
+
+    if (result != null) {
+      final file = File(result);
+      await file.writeAsString(jsonString);
+      showSnackbar(context, 'Timetable settings exported successfully.');
+    }
+  }
 }
 
 class AppDefinitions {

--- a/app/lib/applets/timetable/definition.dart
+++ b/app/lib/applets/timetable/definition.dart
@@ -26,4 +26,12 @@ final timeTableDefinition = AppletDefinition(
       return Placeholder();
     }
   },
+  options: {
+    'import': (context, updateSettings) async {
+      await importTimetableSettings(updateSettings);
+    },
+    'export': (context, settings) async {
+      await exportTimetableSettings(settings);
+    },
+  },
 );

--- a/app/lib/applets/timetable/student/student_timetable_view.dart
+++ b/app/lib/applets/timetable/student/student_timetable_view.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:sph_plan/generated/l10n.dart';

--- a/app/lib/applets/timetable/student/student_timetable_view.dart
+++ b/app/lib/applets/timetable/student/student_timetable_view.dart
@@ -7,6 +7,8 @@ import 'package:sph_plan/models/account_types.dart';
 import 'package:sph_plan/utils/random_color.dart';
 import 'package:sph_plan/widgets/combined_applet_builder.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
+import 'package:file_picker/file_picker.dart';
+import 'dart:convert';
 
 import '../../../core/sph/sph.dart';
 import '../../../models/timetable.dart';
@@ -107,6 +109,41 @@ class _StudentTimetableViewState extends State<StudentTimetableView> {
     );
   }
 
+  Future<void> exportTimetableSettings(Map<String, dynamic> settings) async {
+    final jsonString = jsonEncode(settings);
+    final fileName = 'timetable_settings.json';
+    final result = await FilePicker.platform.saveFile(
+      dialogTitle: 'Save Timetable Settings',
+      fileName: fileName,
+    );
+
+    if (result != null) {
+      final file = File(result);
+      await file.writeAsString(jsonString);
+      showSnackbar(context, 'Timetable settings exported successfully.');
+    }
+  }
+
+  Future<void> importTimetableSettings(
+      Future<void> Function(String, dynamic) updateSettings) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+
+    if (result != null && result.files.isNotEmpty) {
+      final file = File(result.files.single.path!);
+      final jsonString = await file.readAsString();
+      final Map<String, dynamic> importedSettings = jsonDecode(jsonString);
+
+      for (var key in importedSettings.keys) {
+        await updateSettings(key, importedSettings[key]);
+      }
+
+      showSnackbar(context, 'Timetable settings imported successfully.');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     var controller = CalendarController();
@@ -163,6 +200,39 @@ class _StudentTimetableViewState extends State<StudentTimetableView> {
                       onPressed: () => widget.openDrawerCb!(),
                     )
                   : null,
+              actions: [
+                IconButton(
+                  icon: Icon(Icons.import_export),
+                  onPressed: () async {
+                    await showModalBottomSheet(
+                      context: context,
+                      builder: (BuildContext context) {
+                        return Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            ListTile(
+                              leading: Icon(Icons.file_upload),
+                              title: Text('Export Timetable Settings'),
+                              onTap: () async {
+                                Navigator.pop(context);
+                                await exportTimetableSettings(settings);
+                              },
+                            ),
+                            ListTile(
+                              leading: Icon(Icons.file_download),
+                              title: Text('Import Timetable Settings'),
+                              onTap: () async {
+                                Navigator.pop(context);
+                                await importTimetableSettings(updateSettings);
+                              },
+                            ),
+                          ],
+                        );
+                      },
+                    );
+                  },
+                ),
+              ],
             ),
             body: Stack(
               children: [


### PR DESCRIPTION
Add import and export functionality for timetable filter settings, including hidden lessons, color, and manually added lessons.

* **app/lib/applets/timetable/student/student_timetable_view.dart**
  - Import `file_picker` and `dart:convert` packages.
  - Add `exportTimetableSettings` function to export timetable settings to a JSON file.
  - Add `importTimetableSettings` function to import timetable settings from a JSON file.
  - Add an `IconButton` to the app bar to trigger import/export actions.
  - Add a modal bottom sheet to select import/export actions.

* **app/lib/applets/timetable/student/student_timetable_settings.dart**
  - Import `file_picker` and `dart:convert` packages.
  - Add `exportTimetableSettings` function to export timetable settings to a JSON file.
  - Add `importTimetableSettings` function to import timetable settings from a JSON file.
  - Add an `IconButton` to the app bar to trigger import/export actions.
  - Add a modal bottom sheet to select import/export actions.

* **app/lib/applets/timetable/definition.dart**
  - Add options for importing and exporting timetable settings.

